### PR TITLE
Add visual tweaks patches

### DIFF
--- a/tweaks/visual/overlay-scrollbar-opacity.patch
+++ b/tweaks/visual/overlay-scrollbar-opacity.patch
@@ -1,0 +1,20 @@
+## This patch sets a minimum opacity for scrollbars.  
+# 
+# I use the OverlayScrollbar feature flag, and enjoy the aesthetic except for
+# the fact that the scrollbar disappears completely.  Being able to see the bar
+# slightly helps to visulize your position on the page as well as letting you
+# know where to move your mouse should you go reaching for it.  
+#
+# I use 0.15 here, but you can adjust that to your liking.  
+
+--- a/cc/input/scrollbar_animation_controller.cc
++++ b/cc/input/scrollbar_animation_controller.cc
+@@ -362,6 +362,8 @@
+ }
+ 
+ void ScrollbarAnimationController::ApplyOpacityToScrollbars(float opacity) {
++  if (opacity < 0.15f)
++    opacity = 0.15f;
+   for (ScrollbarLayerImplBase* scrollbar : Scrollbars()) {
+     DCHECK(scrollbar->is_overlay_scrollbar());
+     float effective_opacity = scrollbar->CanScrollOrientation() ? opacity : 0;

--- a/tweaks/visual/thinner-tabbar-toolbar-bookmarkbar-downloadbar.patch
+++ b/tweaks/visual/thinner-tabbar-toolbar-bookmarkbar-downloadbar.patch
@@ -1,0 +1,94 @@
+## This patch makes the tabbar, toolbar, bookmarkbar, and downloadbar thinner.  
+#
+# These are the values that I'm comfortable with, adjust to your liking.  
+#
+# Even though the download items are set to 24px, that's really a minimum.  
+# Their height is based on the height of two rows of text using your current
+# font, so that could vary depending on your settings.  
+
+--- a/chrome/browser/ui/views/download/download_item_view.cc
++++ b/chrome/browser/ui/views/download/download_item_view.cc
+@@ -120,14 +120,14 @@
+ 
+ // The vertical distance between the item's visual upper bound (as delineated
+ // by the separator on the right) and the edge of the shelf.
+-constexpr int kTopBottomPadding = 6;
++constexpr int kTopBottomPadding = 0;
+ 
+ // The minimum vertical padding above and below contents of the download item.
+ // This is only used when the text size is large.
+ constexpr int kMinimumVerticalPadding = 2 + kTopBottomPadding;
+ 
+ // The normal height of the item which may be exceeded if text is large.
+-constexpr int kDefaultDownloadItemHeight = 48;
++constexpr int kDefaultDownloadItemHeight = 24;
+ 
+ // Amount of time between accessible alert events.
+ constexpr auto kAccessibleAlertInterval = base::TimeDelta::FromSeconds(30);
+--- a/chrome/browser/ui/layout_constants.cc
++++ b/chrome/browser/ui/layout_constants.cc
+@@ -33,13 +33,13 @@
+     case BOOKMARK_BAR_HEIGHT:
+       // The fixed margin ensures the bookmark buttons appear centered relative
+       // to the white space above and below.
+-      static constexpr int kBookmarkBarAttachedVerticalMargin = 4;
++      static constexpr int kBookmarkBarAttachedVerticalMargin = 0;
+       return GetLayoutConstant(BOOKMARK_BAR_BUTTON_HEIGHT) +
+              kBookmarkBarAttachedVerticalMargin;
+     case BOOKMARK_BAR_BUTTON_HEIGHT:
+-      return touch_ui ? 36 : 28;
++      return touch_ui ? 36 : 24;
+     case BOOKMARK_BAR_NTP_HEIGHT:
+-      return touch_ui ? GetLayoutConstant(BOOKMARK_BAR_HEIGHT) : 39;
++      return touch_ui ? GetLayoutConstant(BOOKMARK_BAR_HEIGHT) : 27;
+     case WEB_APP_MENU_BUTTON_SIZE:
+       return 24;
+     case WEB_APP_PAGE_ACTION_ICON_SIZE:
+@@ -47,17 +47,17 @@
+       // stretching the container view.
+       return 16;
+     case LOCATION_BAR_BUBBLE_FONT_VERTICAL_PADDING:
+-      return 2;
++      return 0;
+     case LOCATION_BAR_BUBBLE_ANCHOR_VERTICAL_INSET:
+       return 1;
+     case LOCATION_BAR_CHILD_INTERIOR_PADDING:
+-      return 3;
++      return 1;
+     case LOCATION_BAR_ELEMENT_PADDING:
+       return touch_ui ? 3 : 2;
+     case LOCATION_BAR_HEIGHT:
+       if (OmniboxFieldTrial::RichAutocompletionTwoLineOmnibox())
+         return touch_ui ? 52 : 40;
+-      return touch_ui ? 36 : 28;
++      return touch_ui ? 36 : 24;
+     case LOCATION_BAR_ICON_SIZE:
+       return touch_ui ? 20 : 16;
+     case TAB_AFTER_TITLE_PADDING:
+@@ -67,7 +67,7 @@
+     case TAB_ALERT_INDICATOR_ICON_WIDTH:
+       return touch_ui ? 12 : 16;
+     case TAB_HEIGHT:
+-      return (touch_ui ? 41 : 34) + GetLayoutConstant(TABSTRIP_TOOLBAR_OVERLAP);
++      return (touch_ui ? 41 : 30) + GetLayoutConstant(TABSTRIP_TOOLBAR_OVERLAP);
+     case TAB_PRE_TITLE_PADDING:
+       return 8;
+     case TAB_STACK_DISTANCE:
+@@ -75,7 +75,7 @@
+     case TABSTRIP_TOOLBAR_OVERLAP:
+       return 1;
+     case TOOLBAR_BUTTON_HEIGHT:
+-      return touch_ui ? 48 : 28;
++      return touch_ui ? 48 : 24;
+     case TOOLBAR_ELEMENT_PADDING:
+       return touch_ui ? 0 : 4;
+     case TOOLBAR_STANDARD_SPACING:
+@@ -103,7 +103,7 @@
+     }
+ 
+     case TOOLBAR_INTERIOR_MARGIN:
+-      return touch_ui ? gfx::Insets() : gfx::Insets(4, 8);
++      return touch_ui ? gfx::Insets() : gfx::Insets(0, 8);
+   }
+   NOTREACHED();
+   return gfx::Insets();


### PR DESCRIPTION
This creates a `tweaks/visual` directory with two patches:
A patch to set the minimum opacity for scrollbars.  Useful when using the `OverlayScrollbar` feature flag.  
A patch that makes the tabbar, toolbar, bookmarkbar, and downloadbar thinner.  

Each should be commented well.  Let me know if you'd prefer that to be organized differently.  